### PR TITLE
SpigotReflection: Handle tickTimes for MC 1.21 and MC 1.20.6

### DIFF
--- a/spigot/src/main/java/xyz/jpenilla/tabtps/spigot/util/SpigotReflection.java
+++ b/spigot/src/main/java/xyz/jpenilla/tabtps/spigot/util/SpigotReflection.java
@@ -83,8 +83,10 @@ public final class SpigotReflection {
       tickTimes = "o";
     } else if (ver == 19 || ver == 20 && PaperLib.getMinecraftPatchVersion() < 3) {
       tickTimes = "k";
-    } else if (ver == 20) {
+    } else if (ver == 20 && PaperLib.getMinecraftPatchVersion() < 6) {
       tickTimes = "ac";
+    } else if (ver == 20 || ver == 21) {
+      tickTimes = "ab";
     } else {
       throw new IllegalStateException("Don't know tickTimes field name!");
     }


### PR DESCRIPTION
This fixes the /tps and /mspt commands on 1.21 and 1.20.6 when using Spigot or Paper.

I only technically confirmed the bug in 1.21 Spigot. Haven't checked Paper but I assume it's equally broken without the proper mappings. I put the new version on my server and it's working fine now.

This also fixes #136

Proper nms mapping for this field was sourced from [here](https://mappings.dev/1.21/net/minecraft/server/MinecraftServer.html), which shows that the mapping for this field changed during 1.20.6