### PR TITLE
Fix crash when a player disconnects before joining

### DIFF
--- a/common/src/main/java/xyz/jpenilla/tabtps/common/service/UserService.java
+++ b/common/src/main/java/xyz/jpenilla/tabtps/common/service/UserService.java
@@ -153,13 +153,9 @@ public abstract class UserService<P, U extends User<P>> {
   }
 
   public final void removeUser(final UUID uniqueId) {
-    final U removed = this.userMap.remove(uniqueId);
+    final U removed = this.remove(uniqueId);
     if (removed == null) {
       throw new IllegalStateException("Cannot remove non-existing user " + uniqueId);
-    }
-    this.shutdownDisplays(removed);
-    if (removed.shouldSave()) {
-      this.saveUser(uniqueId, removed);
     }
   }
 
@@ -190,7 +186,21 @@ public abstract class UserService<P, U extends User<P>> {
   }
 
   public final void handleQuit(final P platformPlayer) {
-    this.removeUser(this.uuid(platformPlayer));
+    // A disconnect can happen before the join sequence completed, meaning the user was never
+    // added. There is nothing to clean up in that case, and the server should not crash on it.
+    this.remove(this.uuid(platformPlayer));
+  }
+
+  private U remove(final UUID uniqueId) {
+    final U removed = this.userMap.remove(uniqueId);
+    if (removed == null) {
+      return null;
+    }
+    this.shutdownDisplays(removed);
+    if (removed.shouldSave()) {
+      this.saveUser(uniqueId, removed);
+    }
+    return removed;
   }
 
   private void shutdownDisplays(final U user) {


### PR DESCRIPTION
## Problem

If a player disconnects before the join sequence completes, TabTPS crashes the server. In the linked report the disconnect happens because the client lacks a mod the server requires, so the join is aborted before `UserService#handleJoin` has registered the user. The quit handler then calls `removeUser` unconditionally, which throws `IllegalStateException: Cannot remove non-existing user <uuid>` on the server thread (#316).

## Fix

`handleQuit` now uses an atomic remove-if-present instead of the throwing `removeUser`. When the user was never registered, there is nothing to clean up, so it is a no-op. Cleanup for a registered user is unchanged: displays are shut down and data is saved exactly as before.

I kept `removeUser`'s strict contract (throw when the user is absent) since that is a useful guard for programmatic callers, and instead extracted the shared removal logic into a private `remove` helper that `handleQuit` uses. As a side effect this also removes a potential check-then-act window, since the map operation is now a single `ConcurrentHashMap#remove`.

This is in the common module, so it covers the Paper, Fabric, NeoForge, and Sponge listeners, which all funnel through `handleQuit`.

## Testing

- `gradlew build` passes locally (Gradle 9.6.1, Java toolchain 21 per the repo config).
- I traced all call sites of `removeUser` and `handleQuit` across the four platform modules. `flush()` and `replacePlayer` keep their previous behavior; only the quit path for an absent user changed.
- I could not reproduce the original crash locally: it needs a NeoForge server with TenshiLib plus a client missing that mod. The fix path is small, but if you want a live check, the reporter's reproduction steps in #316 should now end with a normal disconnect and no crash.

## Notes

- One environment note on my side: the `spotlessJavaCheck` task fails on Windows machines with `core.autocrlf=true` because the generated `Messages.java` gets a CRLF expectation while the generator emits LF. That failure exists on `master` for me before any change and is unrelated to this fix, so I verified formatting against the file's existing style by hand. Linux CI should be unaffected.

Closes #316
